### PR TITLE
fix the amthostdb set username argument

### DIFF
--- a/bin/amthostdb
+++ b/bin/amthostdb
@@ -25,7 +25,7 @@ def main():
     parser_set.add_argument('server', metavar='name', help='server name')
     parser_set.add_argument('host', metavar='host')
     parser_set.add_argument('passwd', metavar='passwd')
-    parser_set.add_argument('-U', metavar='username')
+    parser_set.add_argument('-U', metavar='username', dest='user')
     parser_set.add_argument('-S', '--scheme', metavar='scheme', default='http', choices=['http', 'https'])
     parser_set.add_argument('--tls-ca', metavar='filename')
     parser_set.add_argument('--tls-key', metavar='filename')


### PR DESCRIPTION
Without this, the following command fails.

```console
(.venv) rgl@rgl-desktop:~/Projects/intel-amt-notes$ amthostdb set -U admin test 192.168.1.89 password
Traceback (most recent call last):
  File "/home/rgl/Projects/intel-amt-notes/.venv/bin/amthostdb", line 4, in <module>
    __import__('pkg_resources').run_script('amt==0.9.0', 'amthostdb')
  File "/home/rgl/Projects/intel-amt-notes/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/home/rgl/Projects/intel-amt-notes/.venv/lib/python3.8/site-packages/pkg_resources/__init__.py", line 1462, in run_script
    exec(code, namespace, namespace)
  File "/home/rgl/Projects/intel-amt-notes/.venv/lib/python3.8/site-packages/amt-0.9.0-py3.8.egg/EGG-INFO/scripts/amthostdb", line 61, in <module>
    sys.exit(main())
  File "/home/rgl/Projects/intel-amt-notes/.venv/lib/python3.8/site-packages/amt-0.9.0-py3.8.egg/EGG-INFO/scripts/amthostdb", line 51, in main
    cert=args.tls_cert, user=args.user)

```
